### PR TITLE
add special handling of null-terminated strings

### DIFF
--- a/defender2yara/util/__init__.py
+++ b/defender2yara/util/__init__.py
@@ -1,1 +1,1 @@
-from .utils import hexdump,is_printable_ascii,is_printable_utf16_le_ascii
+from .utils import hexdump,is_printable_ascii,is_printable_ascii_null_terminated,is_printable_utf16_le_ascii,is_printable_utf16_le_ascii_null_terminated

--- a/defender2yara/util/utils.py
+++ b/defender2yara/util/utils.py
@@ -37,6 +37,21 @@ def is_printable_ascii(data: Union[bytes,str]) -> bool:
         raise ValueError("Not supported type.")
 
 
+def is_printable_ascii_null_terminated(data:bytes) -> bool:
+    """
+    Check if the byte data is printable ASCII and null-terminated.
+
+    Args:
+        data (bytes): The byte data to check.
+
+    Returns:
+        bool: True if the byte data is printable ASCII and null-terminated, False otherwise.
+    """
+    if len(data) == 0 or data[-1] != 0:
+        return False
+    return is_printable_ascii(data[:-1])
+
+
 def is_printable_utf16_le_ascii(byte_data:bytes) -> bool:
     """
     Check if the given byte data is encoded as UTF-16-LE and contains only ASCII characters.
@@ -59,6 +74,22 @@ def is_printable_utf16_le_ascii(byte_data:bytes) -> bool:
     except UnicodeDecodeError:
         # If decoding fails, it's not a valid UTF-16-LE encoding
         return False
+
+
+def is_printable_utf16_le_ascii_null_terminated(byte_data:bytes) -> bool:
+    """
+    Check if the given byte data is UTF-16-LE encoded, contains only ASCII characters, and is null-terminated.
+
+    Args:
+        byte_data (bytes): The byte data to check.
+
+    Returns:
+        bool: True if the byte data is UTF-16-LE encoded, contains only ASCII characters, and is null-terminated, False otherwise.
+    """
+    if len(byte_data) < 2 or byte_data[-2:] != b'\x00\x00':
+        # Check if the byte data is at least 2 bytes long and null-terminated
+        return False
+    return is_printable_utf16_le_ascii(byte_data[:-2])
 
 
 def is_ascii(c:int) -> bool:


### PR DESCRIPTION
I'm not very familiar with python. There should be a way to make the code more elegant.

'\x00' with wide means two zero bytes. '\x00' with ascii means single zero byte.

then:

```
rule VirTool_Win32_UACBypassExp_D_2147852914_0
{
    meta:
        author = "defender2yara"
        detection_name = "VirTool:Win32/UACBypassExp.gen!D"
        threat_id = "2147852914"
        type = "VirTool"
        platform = "Win32: Windows 32-bit platform"
        family = "UACBypassExp"
        severity = "Critical"
        info = "gen: malware that is detected using a generic signature"
        signature_type = "SIGNATURE_TYPE_CMDHSTR_EXT"
        threshold = "1"
        strings_accuracy = "High"
    strings:
        $x_1_1 = {5c 00 63 00 6d 00 64 00 2e 00 65 00 78 00 65 00 00 00}  //weight: 1, accuracy: High
        $x_1_2 = {5c 00 70 00 6f 00 77 00 65 00 72 00 73 00 68 00 65 00 6c 00 6c 00 2e 00 65 00 78 00 65 00 00 00}  //weight: 1, accuracy: High
        $x_1_3 = {5c 00 57 00 53 00 63 00 72 00 69 00 70 00 74 00 2e 00 65 00 78 00 65 00 00 00}  //weight: 1, accuracy: High
        $x_1_4 = {5c 00 6d 00 73 00 68 00 74 00 61 00 2e 00 65 00 78 00 65 00 00 00}  //weight: 1, accuracy: High
        $x_1_5 = {5c 00 72 00 75 00 6e 00 64 00 6c 00 6c 00 33 00 32 00 2e 00 65 00 78 00 65 00 00 00}  //weight: 1, accuracy: High
        $x_1_6 = "-MpPreference -Exclusion" wide //weight: 1
        $x_1_7 = " vbscript:Execute(" wide //weight: 1
        $x_1_8 = "C:\\Users\\public\\" wide //weight: 1
        $x_1_9 = "\\AppData\\Roaming\\" wide //weight: 1
    condition:
        (filesize < 20MB) and
        (1 of ($x*))
}
```

now:

```
rule VirTool_Win32_UACBypassExp_D_2147852914_0
{
    meta:
        author = "defender2yara"
        detection_name = "VirTool:Win32/UACBypassExp.gen!D"
        threat_id = "2147852914"
        type = "VirTool"
        platform = "Win32: Windows 32-bit platform"
        family = "UACBypassExp"
        severity = "Critical"
        info = "gen: malware that is detected using a generic signature"
        signature_type = "SIGNATURE_TYPE_CMDHSTR_EXT"
        threshold = "1"
        strings_accuracy = "High"
    strings:
        $x_1_1 = "\\cmd.exe\x00" wide //weight: 1
        $x_1_2 = "\\powershell.exe\x00" wide //weight: 1
        $x_1_3 = "\\WScript.exe\x00" wide //weight: 1
        $x_1_4 = "\\mshta.exe\x00" wide //weight: 1
        $x_1_5 = "\\rundll32.exe\x00" wide //weight: 1
        $x_1_6 = "-MpPreference -Exclusion" wide //weight: 1
        $x_1_7 = " vbscript:Execute(" wide //weight: 1
        $x_1_8 = "C:\\Users\\public\\" wide //weight: 1
        $x_1_9 = "\\AppData\\Roaming\\" wide //weight: 1
    condition:
        (filesize < 20MB) and
        (1 of ($x*))
}
```
